### PR TITLE
Ubuntu update to 20.04

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL Will Fawcett <willfaw@gmail.com>
 
 # Get OS 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:16.04
-MAINTAINER Will Fawcett <willfaw@gmail.com>
+FROM ubuntu:18.04
+LABEL Will Fawcett <willfaw@gmail.com>
 
 # Get OS 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Dockerfile had been pulling Ubuntu 16.04.

This is not necessarily a problem, but decided to update to the latest LTS version. 20.04, just in case we start running into compatibility issues or unmaintained packages, security vulnerabilities, etc.

We now pull the ubuntu:20.04 base image, and I confirm that Atmos still completes a run as expected.

Also minor update: the "MAINTAINER" kwd was depracted, so I changed it to "LABEL"