### PR TITLE
Atmos submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "docker/atmos"]
+	path = docker/atmos
+	url = https://github.com/PyAtmos/atmos_fdl.git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,32 +1,28 @@
 FROM ubuntu:20.04
 LABEL Will Fawcett <willfaw@gmail.com>
 
-# Get OS 
+COPY atmos /code/atmos
+
+# Install needed OS pkgs
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gfortran \
-        git \
         build-essential \
         ca-certificates &&\
-    rm -rf /var/lib/apt/lists/*
-
-# dummy command for docker 
-RUN echo hello world 2
-
-# Get ATMOS
-RUN mkdir /code/ && cd /code/ && git clone https://gitlab.com/frontierdevelopmentlab/astrobiology/atmos.git
-RUN export ATMOSDIR=/code/atmos 
-
-# Sort out AMTOS files 
-RUN cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/in.dist  /code/atmos/PHOTOCHEM/in.dist; cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/input_photchem.dat /code/atmos/PHOTOCHEM/INPUTFILES/; cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/reactions.rx /code/atmos/PHOTOCHEM/INPUTFILES/; cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/parameters.inc /code/atmos/PHOTOCHEM/INPUTFILES/; cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/species.dat /code/atmos/PHOTOCHEM/INPUTFILES/; cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/PLANET.dat /code/atmos/PHOTOCHEM/INPUTFILES/; cp /code/atmos/CLIMA/IO/TEMPLATES/ModernEarth/input_clima.dat  /code/atmos/CLIMA/IO 
-
-# Check correct species file 
-RUN echo species.dat; cat /code/atmos/PHOTOCHEM/INPUTFILES/species.dat
-
-# Compile and run photo
-RUN cd /code/atmos && make -f PhotoMake && ./Photo.run
-
-# Compile and run clima 
-RUN cd /code/atmos && make -f ClimaMake && ./Clima.run
-
-# Make sure we're in the root directory 
-RUN cd / 
+    rm -rf /var/lib/apt/lists/* &&\
+    export ATMOSDIR=/code/atmos &&\ 
+    # Sort out ATMOS files
+    cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/in.dist /code/atmos/PHOTOCHEM/in.dist &&\
+    cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/input_photchem.dat /code/atmos/PHOTOCHEM/INPUTFILES/ &&\
+    cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/reactions.rx /code/atmos/PHOTOCHEM/INPUTFILES/ &&\
+    cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/parameters.inc /code/atmos/PHOTOCHEM/INPUTFILES/ &&\
+    cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/species.dat /code/atmos/PHOTOCHEM/INPUTFILES/ &&\
+    cp /code/atmos/PHOTOCHEM/INPUTFILES/TEMPLATES/ModernEarth/PLANET.dat /code/atmos/PHOTOCHEM/INPUTFILES/ &&\
+    cp /code/atmos/CLIMA/IO/TEMPLATES/ModernEarth/input_clima.dat  /code/atmos/CLIMA/IO &&\
+    # Check correct species file
+    echo species.dat; cat /code/atmos/PHOTOCHEM/INPUTFILES/species.dat  &&\
+    # Compile and run photo
+    cd /code/atmos && make -f PhotoMake && ./Photo.run &&\
+    # Compile and run clima 
+    cd /code/atmos && make -f ClimaMake && ./Clima.run &&\
+    # Make sure we're in the root directory 
+    cd / 


### PR DESCRIPTION
Added atmos (the version used for FDL 2018's The Big Run) as a submodule in the `docker` subdir, so that during build, docker can just assume atmos is already there and copy it into the container instead of needing to install git, etc.

Also streamlined a little bit by combing into a single RUN command.

Although honestly I'd like to here some more recent dockerfile best practice wisdom as to whether it's really necessary to combine RUN targets like this with later versions of Docker?