### PR TITLE
Roll back to Ubuntu 18.04 which

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 LABEL Will Fawcett <willfaw@gmail.com>
 
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
After looking for ways to make the image lighter, I found "Minimal Ubuntu"

Apparently the version of Ubuntu 18.04 on Dockerhub IS in fact the Minimal Ubuntu version.
So rolling back to 18.04 for now as a compromise between updating and minimizing.

Presumably the 20.04 minimal version will be released soon enough, and we can upgrade to it later.

```
Using Minimal Images from Dockerhub

On Dockerhub, the new Ubuntu 18.04 LTS image is now the new Minimal Ubuntu 18.04 image. Launching a Docker  instance with docker run ubuntu:18.04  therefore launches a Docker instance with the latest Minimal Ubuntu.
```